### PR TITLE
Use `switch-to-buffer' rather than `switch-to-buffer-here'.

### DIFF
--- a/floobits.el
+++ b/floobits.el
@@ -139,7 +139,7 @@
     (error nil))
   (message "Launching Floobits python agent...")
   (setq floobits-python-agent (start-process "" "*Floobits*" floobits-python-path))
-  (switch-to-buffer-here "*Floobits*")
+  (switch-to-buffer "*Floobits*")
   (set-process-filter floobits-python-agent 'floobits-agent-listener)
   (accept-process-output floobits-python-agent 2)
   (process-kill-without-query floobits-python-agent))


### PR DESCRIPTION
I got a "floobits-launch-agent: Symbol's function definition is void: switch-to-buffer-here" with GNU Emacs 24.3.1 (x86_64-apple-darwin12.2.1, Carbon Version 1.6.0 AppKit 1187.34) 

Don't know what the -here does differently, but switch-to-buffer works for me -- would it make sense to switch?
