### PR TITLE
Fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ If you have [el-get](https://github.com/dimitri/el-get), simply `M-x el-get-inst
       "secret": "your_api_secret_not_your_password"
     }
   }
-}```
+}
+```
 
 ## Usage
 


### PR DESCRIPTION
There was a missing newline before the end of the code block, causing the last half of the readme to all be verbatim instead of rendered.