### PR TITLE
Chat messages

### DIFF
--- a/floo/agent_connection.py
+++ b/floo/agent_connection.py
@@ -174,4 +174,8 @@ class AgentConnection(floo_handler.FlooHandler):
         })
 
     def _on_msg(self, data):
-        msg.log('msg')
+        self.to_emacs('msg', {
+            'data': data['data'],
+            'username': data.get('username', 'unknown user'),
+            'user_id': data['user_id']
+        })

--- a/floo/emacs_handler.py
+++ b/floo/emacs_handler.py
@@ -169,6 +169,14 @@ class EmacsHandler(base.BaseHandler):
             return
         self.bufs_changed.append(view.buf['id'])
 
+    def _on_msg(self, req):
+        msg_json = {
+            'name': 'msg',
+            'data': req['data']
+        }
+        msg.debug("sending chat message upstream: %s" % msg_json)
+        self.send_to_floobits(msg_json)
+
     @has_perm('highlight')
     def _on_highlight(self, req):
         view = self.get_view_by_path(req['full_path'])

--- a/floobits.el
+++ b/floobits.el
@@ -684,8 +684,11 @@ A process is considered alive if its status is `run', `open',
 (defun floobits-event-open_file (req)
   (find-file (floobits--get-item req "filename")))
 
-(defun floobits-event-message (req)
-  (message "%s" (floobits--get-item req "message")))
+(defun floobits-event-msg (req)
+  "Process incoming chat messages."
+  (message "Floobits message from %s: %s"
+           (floobits--get-item req "username")
+           (floobits--get-item req "data")))
 
 (defun floobits-event-rename (req)
   (let* ((new-name (floobits--get-item req "new_name"))

--- a/floobits.el
+++ b/floobits.el
@@ -246,6 +246,13 @@ command before you can log in to the website."
   (floobits-create-connection (lambda () (floobits-send-to-agent () 'pinocchio))))
 
 ;;;###autoload
+(defun floobits-send-message (msg)
+  "Send chat message to all collaborators in Floobits workspace."
+  (interactive "sMessage: ")
+  (when (and floobits-conn (not (string= msg "")))
+    (floobits-send-to-agent `((data . ,msg)) "msg")))
+
+;;;###autoload
 (defun floobits-share-dir-public (dir-to-share)
   "Create public Floobits workspace and add contents of DIR-TO-SHARE.
 If DIR-TO-SHARE does not it exist, it will be created.  If the


### PR DESCRIPTION
**Work in progress.**

Adds inbound (#76) + outbound message handling.

Outbound messages can be sent using the `floobits-send-message` command. Inbound messages will be displayed in the minibuffer as well as in the `*Floobits Chat*` buffer, which contains a timestamped log of all messages sent / received, including clickable URLs and email addresses. The `RET` key can be used from the `*Floobits Chat*` buffer to invoke `floobits-send-message`.

Everything mentioned works well but I'm playing with different ideas about what the final interface should be (should all types of notifications be included in one buffer rather than just chat messages? Something akin to #36?). Sharing for feedback / collaboration.

### TODO

- [ ] Probably better if we use message timestamps instead of system time.
- [ ] Display appropriate user name for outbound messages (not `me`).
- [ ] Apply faces for highlighting.
- [ ] Decide how to notify when workspace has changed.
- [ ] Support typing into buffer to send messages (investigate `comint-mode`).
- [ ] Show count of unread messages on modeline?
